### PR TITLE
Present Self Attested Demographic Data and Vaccination Credentials

### DIFF
--- a/App.js
+++ b/App.js
@@ -153,7 +153,7 @@ const App = (props) => {
                 path="/setup-wizard"
                 render={() => (
                   <SetupWizard setAuthenticated={setAuthenticated}>
-                    <Terms
+                    {/* <Terms
                       title={PrivacyPolicy.title}
                       message={PrivacyPolicy.text}
                     />
@@ -161,7 +161,7 @@ const App = (props) => {
                     <PassportDirections />
                     <Passport />
                     <ContactInfo />
-                    <AddressInfo />
+                    <AddressInfo /> */}
                     <ConnectNow />
                     <Confirmed />
                   </SetupWizard>

--- a/App.js
+++ b/App.js
@@ -153,7 +153,7 @@ const App = (props) => {
                 path="/setup-wizard"
                 render={() => (
                   <SetupWizard setAuthenticated={setAuthenticated}>
-                    {/* <Terms
+                    <Terms
                       title={PrivacyPolicy.title}
                       message={PrivacyPolicy.text}
                     />
@@ -161,7 +161,7 @@ const App = (props) => {
                     <PassportDirections />
                     <Passport />
                     <ContactInfo />
-                    <AddressInfo /> */}
+                    <AddressInfo />
                     <ConnectNow />
                     <Confirmed />
                   </SetupWizard>

--- a/components/Message/index.js
+++ b/components/Message/index.js
@@ -68,19 +68,6 @@ function Message(props) {
             </Text>
           </TouchableOpacity>
         ) : null}
-        {props.send ? (
-          <TouchableOpacity
-            style={[
-              AppStyles.button,
-              AppStyles.confirmBackground,
-              {marginTop: 30},
-            ]}
-            onPress={() => props.sendData}>
-            <Text style={[AppStyles.h2, AppStyles.textSecondary]}>
-              Send Data
-            </Text>
-          </TouchableOpacity>
-        ) : null}
         {props.children}
         {props.button ? (
           <TouchableOpacity

--- a/components/Message/index.js
+++ b/components/Message/index.js
@@ -68,6 +68,19 @@ function Message(props) {
             </Text>
           </TouchableOpacity>
         ) : null}
+        {props.send ? (
+          <TouchableOpacity
+            style={[
+              AppStyles.button,
+              AppStyles.confirmBackground,
+              {marginTop: 30},
+            ]}
+            onPress={() => props.sendData}>
+            <Text style={[AppStyles.h2, AppStyles.textSecondary]}>
+              Send Data
+            </Text>
+          </TouchableOpacity>
+        ) : null}
         {props.children}
         {props.button ? (
           <TouchableOpacity

--- a/components/Message/index.js
+++ b/components/Message/index.js
@@ -23,8 +23,8 @@ function Message(props) {
   let history = useHistory()
 
   return (
-    <View style={[Styles.msgView, AppStyles.altBg]}>
-      <AppHeaderLarge alt={true} />
+    <View style={[Styles.msgView, props.defaultBg ? null : AppStyles.altBg]}>
+      <AppHeaderLarge alt={props.defaultBg ? false : true} />
       <View style={[Styles.innerView, props.bgColor]}>
         {props.image ? (
           <Image

--- a/components/Registration/ConnectNow/index.js
+++ b/components/Registration/ConnectNow/index.js
@@ -33,10 +33,6 @@ function ConnectNow(props) {
     console.log('- - - - EVENT: ', event)
     switch (event.proofRecord.state) {
       case ProofState.RequestReceived:
-        const connectionRecord = await agentContext.agent.connections.getById(
-          event.proofRecord.connectionId,
-        )
-
         try {
           console.log(
             'Proof Request Message:',
@@ -106,6 +102,7 @@ function ConnectNow(props) {
           setProofId(event.proofRecord.id)
 
           setLoadingOverlayVisible(false)
+          console.log("Compiled requested Credentials")
         } catch (error) {
           console.warn('Unable to create proof for request', error)
         }
@@ -127,7 +124,7 @@ function ConnectNow(props) {
       event.connectionRecord.state === ConnectionState.Complete
     ) {
       try {
-        console.log('Connected to government agent, sending data transfer')
+        console.log('Connected to government agent')
 
         console.log('Setup data:', props.setupData)
 
@@ -146,10 +143,6 @@ function ConnectNow(props) {
     console.log('You are now queued to connect')
     setLoadingOverlayVisible(true)
     setQueued(true)
-    console.log('IMPORTANT')
-    if (agentContext.agent.connections) {
-      console.log('connections')
-    }
   }, [])
 
   useEffect(() => {
@@ -183,13 +176,6 @@ function ConnectNow(props) {
     }
   })
 
-  const confirmEntry = async () => {
-    console.log('You are now queued to connect')
-    setLoadingOverlayVisible(true)
-    setQueued(true)
-    console.log('IMPORTANT', agentContext.loading)
-  }
-
   const connect = async () => {
     console.log('Invitation:', Config.GOVERNMENT_INVITATION)
     const invitationRecord = await decodeInvitationFromUrl(
@@ -210,6 +196,7 @@ function ConnectNow(props) {
   const presentProof = async () => {
     setLoadingOverlayVisible(true)
     try {
+      console.log("Sending Presentation to Government Agent")
       await agentContext.agent.proofs.acceptRequest(proofId, userCredential)
       props.incrementScreen()
     } catch (error) {

--- a/components/Registration/ConnectNow/index.js
+++ b/components/Registration/ConnectNow/index.js
@@ -192,12 +192,8 @@ function ConnectNow(props) {
 
   const connect = async () => {
     console.log('Invitation:', Config.GOVERNMENT_INVITATION)
-    // const invitationRecord = await decodeInvitationFromUrl(
-    //   Config.GOVERNMENT_INVITATION,
-    // )
-
     const invitationRecord = await decodeInvitationFromUrl(
-      'http://happy-cat-18.tun1.indiciotech.io?c_i=eyJAdHlwZSI6ICJkaWQ6c292OkJ6Q2JzTlloTXJqSGlxWkRUVUFTSGc7c3BlYy9jb25uZWN0aW9ucy8xLjAvaW52aXRhdGlvbiIsICJAaWQiOiAiMWY0ZjdkZGUtOTMwNC00NzA3LWFjNmQtZTdjMDU4MzJmOTI1IiwgInNlcnZpY2VFbmRwb2ludCI6ICJodHRwOi8vaGFwcHktY2F0LTE4LnR1bjEuaW5kaWNpb3RlY2guaW8iLCAibGFiZWwiOiAiYm9iIiwgInJlY2lwaWVudEtleXMiOiBbIkNhNmVUQ2huU3RTVm5ZVGZjWkJMODhGWEJFMWE1REw5RnBqQUJ1MVFqNjVZIl19',
+      Config.GOVERNMENT_INVITATION,
     )
 
     console.log('New Invitation:', invitationRecord)

--- a/components/Registration/ConnectNow/index.js
+++ b/components/Registration/ConnectNow/index.js
@@ -47,51 +47,28 @@ function ConnectNow(props) {
             event.proofRecord.requestMessage.indyProofRequest,
           )
 
-          // let DOB = new Date(
-          //   `${props.setupData.PassportData.dob.month}/${props.setupData.PassportData.dob.day}/${props.setupData.PassportData.dob.year}`,
-          // )
+          let DOB = new Date(
+            `${props.setupData.PassportData.dob.month}/${props.setupData.PassportData.dob.day}/${props.setupData.PassportData.dob.year}`,
+          )
 
-          // const userData = {
-          //   email: props.setupData.ContactInfo.email,
-          //   phone: props.setupData.ContactInfo.phone,
-          //   address: {
-          //     address_1: '',
-          //     address_2: '',
-          //     city: '',
-          //     state: props.setupData.AddressInfo.state,
-          //     country: props.setupData.AddressInfo.country,
-          //     zip_code: '',
-          //   },
-          //   passport_number: '',
-          //   surname: props.setupData.PassportData.names.lastName,
-          //   given_names: props.setupData.PassportData.names.names.join(' '),
-          //   sex: props.setupData.PassportData.sex.full,
-          //   date_of_birth: DOB.toISOString(),
-          //   place_of_birth: '',
-          //   nationality: '',
-          //   date_of_issue: '',
-          //   date_of_expiration: '',
-          //   type: '',
-          //   code: '',
-          //   authority: '',
-          //   photo: '',
-          // }
+          // Using JSON.stringify to pass nested object to requested credential, can be refined
+
           const userData = {
-            email: '',
-            phone: '',
-            address: {
+            email: props.setupData.ContactInfo.email,
+            phone: props.setupData.ContactInfo.phone,
+            address: JSON.stringify({
               address_1: '',
               address_2: '',
               city: '',
-              state: '',
-              country: '',
+              state: props.setupData.AddressInfo.state,
+              country: props.setupData.AddressInfo.country,
               zip_code: '',
-            },
+            }),
             passport_number: '',
-            surname: '',
-            given_names: '',
-            sex: '',
-            date_of_birth: '',
+            surname: props.setupData.PassportData.names.lastName,
+            given_names: props.setupData.PassportData.names.names.join(' '),
+            sex: props.setupData.PassportData.sex.full,
+            date_of_birth: DOB.toISOString(),
             place_of_birth: '',
             nationality: '',
             date_of_issue: '',
@@ -258,7 +235,7 @@ function ConnectNow(props) {
                 AppStyles.marginBottomMd,
                 AppStyles.lineHeightMd,
               ]}>
-              Connect to{'\n'}Health Department{'\n'}
+              Connected to{'\n'}Health Department{'\n'}
             </Text>
             {connectionId ? <Text>Successfully connected!</Text> : null}
             <TouchableOpacity
@@ -272,7 +249,7 @@ function ConnectNow(props) {
                 presentProof()
               }}>
               <Text style={[AppStyles.h2, AppStyles.textWhite]}>
-                Connect Now
+                Send Data
               </Text>
             </TouchableOpacity>
           </View>

--- a/components/Registration/ConnectNow/index.js
+++ b/components/Registration/ConnectNow/index.js
@@ -47,7 +47,11 @@ function ConnectNow(props) {
             event.proofRecord.requestMessage.indyProofRequest,
           )
 
-          // const demographicData = {
+          // let DOB = new Date(
+          //   `${props.setupData.PassportData.dob.month}/${props.setupData.PassportData.dob.day}/${props.setupData.PassportData.dob.year}`,
+          // )
+
+          // const userData = {
           //   email: props.setupData.ContactInfo.email,
           //   phone: props.setupData.ContactInfo.phone,
           //   address: {
@@ -58,15 +62,6 @@ function ConnectNow(props) {
           //     country: props.setupData.AddressInfo.country,
           //     zip_code: '',
           //   },
-          // }
-
-          // await storeData('demographicData', demographicData)
-
-          // let DOB = new Date(
-          //   `${props.setupData.PassportData.dob.month}/${props.setupData.PassportData.dob.day}/${props.setupData.PassportData.dob.year}`,
-          // )
-
-          // const passportData = {
           //   passport_number: '',
           //   surname: props.setupData.PassportData.names.lastName,
           //   given_names: props.setupData.PassportData.names.names.join(' '),
@@ -81,18 +76,37 @@ function ConnectNow(props) {
           //   authority: '',
           //   photo: '',
           // }
+          const userData = {
+            email: '',
+            phone: '',
+            address: {
+              address_1: '',
+              address_2: '',
+              city: '',
+              state: '',
+              country: '',
+              zip_code: '',
+            },
+            passport_number: '',
+            surname: '',
+            given_names: '',
+            sex: '',
+            date_of_birth: '',
+            place_of_birth: '',
+            nationality: '',
+            date_of_issue: '',
+            date_of_expiration: '',
+            type: '',
+            code: '',
+            authority: '',
+            photo: '',
+          }
 
-          // await storeData('passportData', passportData)
+          await storeData('userData', userData)
 
           let requestedCredential = new RequestedCredentials({
             selfAttestedAttributes: {
-              email: 'asdf@gmail.com',
-              address: 'ABC 123 Street',
-              surname: 'brown',
-              given_names: 'steve',
-              sex: 'male',
-              date_of_birth: '1-20-1992',
-              phone: '555-555-1234',
+              ...userData,
             },
           })
 
@@ -152,7 +166,13 @@ function ConnectNow(props) {
   }
 
   useEffect(() => {
-    confirmEntry()
+    console.log('You are now queued to connect')
+    setLoadingOverlayVisible(true)
+    setQueued(true)
+    console.log('IMPORTANT')
+    if (agentContext.agent.connections) {
+      console.log('connections')
+    }
   }, [])
 
   useEffect(() => {
@@ -165,16 +185,16 @@ function ConnectNow(props) {
         ProofEventType.StateChanged,
         proofsEventHandler,
       )
-    }
-    return function () {
-      agentContext.agent.connections.events.removeListener(
-        ConnectionEventType.StateChanged,
-        connectionEventHandler,
-      )
-      agentContext.agent.proofs.events.removeListener(
-        ProofEventType.StateChanged,
-        proofsEventHandler,
-      )
+      return function () {
+        agentContext.agent.connections.events.removeListener(
+          ConnectionEventType.StateChanged,
+          connectionEventHandler,
+        )
+        agentContext.agent.proofs.events.removeListener(
+          ProofEventType.StateChanged,
+          proofsEventHandler,
+        )
+      }
     }
   })
 
@@ -190,6 +210,7 @@ function ConnectNow(props) {
     console.log('You are now queued to connect')
     setLoadingOverlayVisible(true)
     setQueued(true)
+    console.log('IMPORTANT', agentContext.loading)
   }
 
   const connect = async () => {
@@ -199,7 +220,7 @@ function ConnectNow(props) {
     // )
 
     const invitationRecord = await decodeInvitationFromUrl(
-      'http://witty-kangaroo-62.tun1.indiciotech.io?c_i=eyJAdHlwZSI6ICJkaWQ6c292OkJ6Q2JzTlloTXJqSGlxWkRUVUFTSGc7c3BlYy9jb25uZWN0aW9ucy8xLjAvaW52aXRhdGlvbiIsICJAaWQiOiAiNzIyOWFkODQtZTE3ZS00OTY4LWE5NjQtYWZkOTdhMGZlNTkyIiwgInNlcnZpY2VFbmRwb2ludCI6ICJodHRwOi8vd2l0dHkta2FuZ2Fyb28tNjIudHVuMS5pbmRpY2lvdGVjaC5pbyIsICJyZWNpcGllbnRLZXlzIjogWyJGQmpWTWRDYTZ2WG1oRTExN1JrR2pnMnNIdjJSV0plV1lUdG85Tmd4RkVwZSJdLCAibGFiZWwiOiAiYWxpY2UifQ==',
+      'http://happy-cat-18.tun1.indiciotech.io?c_i=eyJAdHlwZSI6ICJkaWQ6c292OkJ6Q2JzTlloTXJqSGlxWkRUVUFTSGc7c3BlYy9jb25uZWN0aW9ucy8xLjAvaW52aXRhdGlvbiIsICJAaWQiOiAiMWY0ZjdkZGUtOTMwNC00NzA3LWFjNmQtZTdjMDU4MzJmOTI1IiwgInNlcnZpY2VFbmRwb2ludCI6ICJodHRwOi8vaGFwcHktY2F0LTE4LnR1bjEuaW5kaWNpb3RlY2guaW8iLCAibGFiZWwiOiAiYm9iIiwgInJlY2lwaWVudEtleXMiOiBbIkNhNmVUQ2huU3RTVm5ZVGZjWkJMODhGWEJFMWE1REw5RnBqQUJ1MVFqNjVZIl19',
     )
 
     console.log('New Invitation:', invitationRecord)

--- a/components/Registration/ConnectNow/index.js
+++ b/components/Registration/ConnectNow/index.js
@@ -77,27 +77,27 @@ function ConnectNow(props) {
 
           await storeData('userData', userData)
 
-          let requestedCredential = new RequestedCredentials({
+          let requestedCredentials = new RequestedCredentials({
             selfAttestedAttributes: {
               ...userData,
             },
           })
 
-          setUserCredential(requestedCredential)
+          setUserCredential(requestedCredentials)
 
-          //Check that requested attributes are present
-          let attributes = Object.entries(
-            event.proofRecord.requestMessage.indyProofRequest
-              .requestedAttributes,
+          //Check to see if self attested user data would fufill this request
+          let requestedAttributes = Object.keys(
+            event.proofRecord.requestMessage.indyProofRequest.requestedAttributes,
           )
 
-          attributes.forEach((attr) => {
-            let currentAttribute = attr[0]
-            if (!requestedCredential.selfAttestedAttributes[currentAttribute]) {
-              console.warn('Missing required attribute: ', currentAttribute)
-              setVerifiable(false)
-            }
+          //Determine if user data is sufficient for proof request
+          const sufficientData = requestedAttributes.every((requestedAttribute) => {
+            return requestedCredentials.selfAttestedAttributes[requestedAttribute]
           })
+
+          if(!sufficientData){
+            setVerifiable(false)
+          }
 
           setProofId(event.proofRecord.id)
 

--- a/components/Registration/ConnectNow/index.js
+++ b/components/Registration/ConnectNow/index.js
@@ -4,6 +4,7 @@ import {Text, TouchableOpacity, View} from 'react-native'
 import {useHistory} from 'react-router-native'
 import AppHeaderLarge from '../../AppHeaderLarge/index.js'
 import LoadingOverlay from '../../LoadingOverlay/index.js'
+import Message from '../../Message/index.js'
 import AppStyles from '@assets/styles'
 import AgentContext from '../../AgentProvider/index.js'
 import {storeData} from '../../../utils/storage'
@@ -11,16 +12,121 @@ import {
   ConnectionEventType,
   ConnectionState,
   decodeInvitationFromUrl,
+  ProofEventType,
+  ProofState,
+  RequestedCredentials,
 } from 'aries-framework'
 
 function ConnectNow(props) {
   //Reference to the agent context
   const agentContext = useContext(AgentContext)
 
-  const [loadingOverlayVisible, setLoadingOverlayVisible] = useState(false)
+  const [loadingOverlayVisible, setLoadingOverlayVisible] = useState(true)
   const [connectionId, setConnectionId] = useState('')
+  const [proofId, setProofId] = useState('')
+  const [userCredential, setUserCredential] = useState(null)
+  const [verifiable, setVerifiable] = useState(true)
 
   const [queued, setQueued] = useState(false)
+
+  const proofsEventHandler = async (event) => {
+    console.log('- - - - EVENT: ', event)
+    switch (event.proofRecord.state) {
+      case ProofState.RequestReceived:
+        const connectionRecord = await agentContext.agent.connections.getById(
+          event.proofRecord.connectionId,
+        )
+
+        try {
+          console.log(
+            'Proof Request Message:',
+            event.proofRecord.requestMessage,
+          )
+          console.log(
+            'Proof Request:',
+            event.proofRecord.requestMessage.indyProofRequest,
+          )
+
+          // const demographicData = {
+          //   email: props.setupData.ContactInfo.email,
+          //   phone: props.setupData.ContactInfo.phone,
+          //   address: {
+          //     address_1: '',
+          //     address_2: '',
+          //     city: '',
+          //     state: props.setupData.AddressInfo.state,
+          //     country: props.setupData.AddressInfo.country,
+          //     zip_code: '',
+          //   },
+          // }
+
+          // await storeData('demographicData', demographicData)
+
+          // let DOB = new Date(
+          //   `${props.setupData.PassportData.dob.month}/${props.setupData.PassportData.dob.day}/${props.setupData.PassportData.dob.year}`,
+          // )
+
+          // const passportData = {
+          //   passport_number: '',
+          //   surname: props.setupData.PassportData.names.lastName,
+          //   given_names: props.setupData.PassportData.names.names.join(' '),
+          //   sex: props.setupData.PassportData.sex.full,
+          //   date_of_birth: DOB.toISOString(),
+          //   place_of_birth: '',
+          //   nationality: '',
+          //   date_of_issue: '',
+          //   date_of_expiration: '',
+          //   type: '',
+          //   code: '',
+          //   authority: '',
+          //   photo: '',
+          // }
+
+          // await storeData('passportData', passportData)
+
+          let requestedCredential = new RequestedCredentials({
+            selfAttestedAttributes: {
+              email: 'asdf@gmail.com',
+              address: 'ABC 123 Street',
+              surname: 'brown',
+              given_names: 'steve',
+              sex: 'male',
+              date_of_birth: '1-20-1992',
+              phone: '555-555-1234',
+            },
+          })
+
+          setUserCredential(requestedCredential)
+
+          //Check that requested attributes are present
+          let attributes = Object.entries(
+            event.proofRecord.requestMessage.indyProofRequest
+              .requestedAttributes,
+          )
+
+          attributes.forEach((attr) => {
+            let currentAttribute = attr[0]
+            if (!requestedCredential.selfAttestedAttributes[currentAttribute]) {
+              console.warn('Missing required attribute: ', currentAttribute)
+              setVerifiable(false)
+            }
+          })
+
+          setProofId(event.proofRecord.id)
+
+          setLoadingOverlayVisible(false)
+        } catch (error) {
+          console.warn('Unable to create proof for request', error)
+        }
+        break
+      case ProofState.PresentationSent:
+        console.log('Presentation Sent')
+        break
+      case ProofState.Done:
+        console.log('Presentation complete')
+        break
+    }
+  }
 
   const connectionEventHandler = async (event) => {
     console.log('Connection Event', event)
@@ -37,61 +143,6 @@ function ConnectNow(props) {
         const governmentConnectionId = connectionId
 
         await storeData('governmentConnectionId', governmentConnectionId)
-
-        const demographicData = {
-          email: props.setupData.ContactInfo.email,
-          phone: props.setupData.ContactInfo.phone,
-          address: {
-            address_1: '',
-            address_2: '',
-            city: '',
-            state: props.setupData.AddressInfo.state,
-            country: props.setupData.AddressInfo.country,
-            zip_code: '',
-          },
-        }
-
-        await storeData('demographicData', demographicData)
-
-        let DOB = new Date(
-          `${props.setupData.PassportData.dob.month}/${props.setupData.PassportData.dob.day}/${props.setupData.PassportData.dob.year}`,
-        )
-
-        const passportData = {
-          passport_number: '',
-          surname: props.setupData.PassportData.names.lastName,
-          given_names: props.setupData.PassportData.names.names.join(' '),
-          sex: props.setupData.PassportData.sex.full,
-          date_of_birth: DOB.toISOString(),
-          place_of_birth: '',
-          nationality: '',
-          date_of_issue: '',
-          date_of_expiration: '',
-          type: '',
-          code: '',
-          authority: '',
-          photo: '',
-        }
-
-        console.log('PassportData:', passportData)
-
-        await storeData('passportData', passportData)
-
-        await agentContext.agent.dataTransfer.sendData(
-          demographicData,
-          event.connectionRecord.id,
-          'transfer.demographicdata',
-          'demographic data attachment',
-        )
-
-        await agentContext.agent.dataTransfer.sendData(
-          passportData,
-          event.connectionRecord.id,
-          'transfer.passportdata',
-          'passport data attachment',
-        )
-
-        props.incrementScreen()
       } catch (error) {
         console.warn('Unable to send data transfer', error)
 
@@ -101,18 +152,29 @@ function ConnectNow(props) {
   }
 
   useEffect(() => {
+    confirmEntry()
+  }, [])
+
+  useEffect(() => {
     if (!agentContext.loading) {
       agentContext.agent.connections.events.on(
         ConnectionEventType.StateChanged,
         connectionEventHandler,
       )
-
-      return function () {
-        agentContext.agent.connections.events.removeListener(
-          ConnectionEventType.StateChanged,
-          connectionEventHandler,
-        )
-      }
+      agentContext.agent.proofs.events.on(
+        ProofEventType.StateChanged,
+        proofsEventHandler,
+      )
+    }
+    return function () {
+      agentContext.agent.connections.events.removeListener(
+        ConnectionEventType.StateChanged,
+        connectionEventHandler,
+      )
+      agentContext.agent.proofs.events.removeListener(
+        ProofEventType.StateChanged,
+        proofsEventHandler,
+      )
     }
   })
 
@@ -132,8 +194,12 @@ function ConnectNow(props) {
 
   const connect = async () => {
     console.log('Invitation:', Config.GOVERNMENT_INVITATION)
+    // const invitationRecord = await decodeInvitationFromUrl(
+    //   Config.GOVERNMENT_INVITATION,
+    // )
+
     const invitationRecord = await decodeInvitationFromUrl(
-      Config.GOVERNMENT_INVITATION,
+      'http://witty-kangaroo-62.tun1.indiciotech.io?c_i=eyJAdHlwZSI6ICJkaWQ6c292OkJ6Q2JzTlloTXJqSGlxWkRUVUFTSGc7c3BlYy9jb25uZWN0aW9ucy8xLjAvaW52aXRhdGlvbiIsICJAaWQiOiAiNzIyOWFkODQtZTE3ZS00OTY4LWE5NjQtYWZkOTdhMGZlNTkyIiwgInNlcnZpY2VFbmRwb2ludCI6ICJodHRwOi8vd2l0dHkta2FuZ2Fyb28tNjIudHVuMS5pbmRpY2lvdGVjaC5pbyIsICJyZWNpcGllbnRLZXlzIjogWyJGQmpWTWRDYTZ2WG1oRTExN1JrR2pnMnNIdjJSV0plV1lUdG85Tmd4RkVwZSJdLCAibGFiZWwiOiAiYWxpY2UifQ==',
     )
 
     console.log('New Invitation:', invitationRecord)
@@ -147,34 +213,59 @@ function ConnectNow(props) {
     setConnectionId(connectionRecord.id)
   }
 
+  const presentProof = async () => {
+    setLoadingOverlayVisible(true)
+    try {
+      await agentContext.agent.proofs.acceptRequest(proofId, userCredential)
+      props.incrementScreen()
+    } catch (error) {
+      console.warn('Unable to create proof for request', error)
+    }
+  }
+
   return (
     <View style={{flex: 1, display: 'flex', flexDirection: 'column'}}>
-      <AppHeaderLarge disabled={true} />
-      <View style={AppStyles.tab}>
-        <Text
-          style={[
-            AppStyles.h2,
-            AppStyles.textPrimary,
-            AppStyles.textCenter,
-            AppStyles.marginBottomMd,
-            AppStyles.lineHeightMd,
-          ]}>
-          Connect to{'\n'}Health Department{'\n'}
-        </Text>
-
-        <TouchableOpacity
-          style={[
-            AppStyles.button,
-            AppStyles.confirmBackground,
-            AppStyles.shadow,
-            {marginTop: 30, height: 64},
-          ]}
-          onPress={() => {
-            confirmEntry()
-          }}>
-          <Text style={[AppStyles.h2, AppStyles.textWhite]}>Connect Now</Text>
-        </TouchableOpacity>
-      </View>
+      {verifiable ? (
+        <>
+          <AppHeaderLarge disabled={true} />
+          <View style={AppStyles.tab}>
+            <Text
+              style={[
+                AppStyles.h2,
+                AppStyles.textPrimary,
+                AppStyles.textCenter,
+                AppStyles.marginBottomMd,
+                AppStyles.lineHeightMd,
+              ]}>
+              Connect to{'\n'}Health Department{'\n'}
+            </Text>
+            {connectionId ? <Text>Successfully connected!</Text> : null}
+            <TouchableOpacity
+              style={[
+                AppStyles.button,
+                AppStyles.confirmBackground,
+                AppStyles.shadow,
+                {marginTop: 30, height: 64},
+              ]}
+              onPress={() => {
+                presentProof()
+              }}>
+              <Text style={[AppStyles.h2, AppStyles.textWhite]}>
+                Connect Now
+              </Text>
+            </TouchableOpacity>
+          </View>
+        </>
+      ) : (
+        <Message
+          title={'Insufficient Credentials'}
+          text={
+            'Unable to verify credentials. Please contact support for more information.'
+          }
+          bgColor={AppStyles.grayBackground}
+          defaultBg={true}
+          textColor={AppStyles.textWhite}></Message>
+      )}
       {loadingOverlayVisible ? <LoadingOverlay /> : null}
     </View>
   )

--- a/components/Workflow/index.js
+++ b/components/Workflow/index.js
@@ -233,7 +233,7 @@ function Workflow(props) {
           console.log(
             'Proof Request Message:',
             event.proofRecord.requestMessage,
-            'Proof Request:',
+            '\nProof Request:',
             event.proofRecord.requestMessage.indyProofRequest,
           )
 
@@ -452,10 +452,6 @@ function Workflow(props) {
   //Event listener for invitation connection update
   const handleConnectionsUpdate = async (event) => {
     console.log('Workflows - Connection update event:', event)
-    if (event.connectionRecord.state === ConnectionState.Complete) {
-      console.log('Connection is active, sending data transfer')
-      
-    }
 
     //If the connection becomes active that was used for our QR Code, generate a new invitation
     if (invitationConnection.connectionRecord) {

--- a/components/Workflow/index.js
+++ b/components/Workflow/index.js
@@ -278,8 +278,9 @@ function Workflow(props) {
                   )
                   await agentContext.agent.proofs.acceptRequest(
                     event.proofRecord.id,
-                    requestedCredential,
+                    requestedCredentials,
                   )
+                  return
                 }
                 break
               case (schemas.has(Schemas.LabResult)):
@@ -293,9 +294,9 @@ function Workflow(props) {
                 )
                 await agentContext.agent.proofs.acceptRequest(
                   event.proofRecord.id,
-                  requestedCredential,
+                  requestedCredentials,
                 )
-                break
+                return
             }
           }
 
@@ -309,6 +310,7 @@ function Workflow(props) {
           setProofRecord(event.proofRecord)
           setWorkflow('requested')
 
+          return
         } catch (error){
           //Error if getRequestedCredentialsForProofRequest fails
           console.log("Unable to get requested credentials for proof request", error)
@@ -328,7 +330,7 @@ function Workflow(props) {
 
           //Determine if user data is sufficient for proof request
           const sufficientData = requestedAttributes.every((requestedAttribute) => {
-            return requestedCredentials.selfAttestedAttributes.includes(requestedAttribute)
+            return requestedCredentials.selfAttestedAttributes[requestedAttribute]
           })
 
           if(sufficientData){
@@ -336,7 +338,7 @@ function Workflow(props) {
             setProofId(event.proofRecord.id)
             setWorkflow('senddata')
 
-            break
+            return
           }
           else{
             console.warn("Missing Required Attributes for Proof Request")
@@ -414,6 +416,191 @@ function Workflow(props) {
         break
     }
   }
+
+  const shareCredentialForTrustedTraveler = async (credDefID) => {
+    console.log(`Proposing presentation to government agent using ${credDefID}`)
+
+    const governmentConnectionId = await getData(
+      'governmentConnectionId',
+    )
+
+    if (!governmentConnectionId) {
+      //TODO: Change to throw an error
+      console.warn('Unable to get government connection Id')
+    }
+
+
+    let presentationPreview
+
+    switch (credDefID){
+      case Config.LAB_RESULT_CRED_DEF_ID:
+        presentationPreview = {
+          '@type':
+            'https://didcomm.org/present-proof/1.0/presentation-preview',
+          attributes: [
+            {
+              name: 'patient_surnames',
+              credentialDefinitionId: credDefID,
+              referent: 'test_results',
+            },
+            {
+              name: 'patient_given_names',
+              credentialDefinitionId: credDefID,
+              referent: 'test_results',
+            },
+            {
+              name: 'patient_date_of_birth',
+              credentialDefinitionId: credDefID,
+              referent: 'test_results',
+            },
+            {
+              name: 'patient_gender_legal',
+              credentialDefinitionId: credDefID,
+              referent: 'test_results',
+            },
+            {
+              name: 'patient_country',
+              credentialDefinitionId: credDefID,
+              referent: 'test_results',
+            },
+            {
+              name: 'patient_email',
+              credentialDefinitionId: credDefID,
+              referent: 'test_results',
+            },
+            {
+              name: 'lab_specimen_collected_date',
+              credentialDefinitionId: credDefID,
+              referent: 'test_results',
+            },
+            {
+              name: 'lab_result',
+              credentialDefinitionId: credDefID,
+              referent: 'test_results',
+            },
+            {
+              name: 'lab_observation_date_time',
+              credentialDefinitionId: credDefID,
+              referent: 'test_results',
+            },
+          ],
+          predicates: [],
+        }
+    
+        setWorkflow('sending-test-result')
+
+        break
+      case Config.VACCINATION_CRED_DEF_ID:
+        presentationPreview = {
+          '@type':
+            'https://didcomm.org/present-proof/1.0/presentation-preview',
+          attributes: [
+            {
+              name: 'patient_surnames',
+              credentialDefinitionId: credDefID,
+              referent: 'test_results',
+            },
+            {
+              name: 'patient_given_names',
+              credentialDefinitionId: credDefID,
+              referent: 'test_results',
+            },
+            {
+              name: 'patient_date_of_birth',
+              credentialDefinitionId: credDefID,
+              referent: 'test_results',
+            },
+            {
+              name: 'patient_gender_legal',
+              credentialDefinitionId: credDefID,
+              referent: 'test_results',
+            },
+            {
+              name: 'patient_country',
+              credentialDefinitionId: credDefID,
+              referent: 'test_results',
+            },
+            {
+              name: 'patient_email',
+              credentialDefinitionId: credDefID,
+              referent: 'test_results',
+            },
+            {
+              name: 'vaccine_administration_date',
+              credentialDefinitionId: credDefID,
+              referent: 'test_results',
+            },
+            {
+              name: 'vaccine_series_complete',
+              credentialDefinitionId: credDefID,
+              referent: 'test_results',
+            },
+          ],
+          predicates: [],
+        }
+    
+        setWorkflow('sending-vaccination')
+
+        break
+      case Config.EXEMPTION_CRED_DEF_ID:
+        presentationPreview = {
+          '@type':
+            'https://didcomm.org/present-proof/1.0/presentation-preview',
+          attributes: [
+            {
+              name: 'patient_surnames',
+              credentialDefinitionId: credDefID,
+              referent: 'test_results',
+            },
+            {
+              name: 'patient_given_names',
+              credentialDefinitionId: credDefID,
+              referent: 'test_results',
+            },
+            {
+              name: 'patient_date_of_birth',
+              credentialDefinitionId: credDefID,
+              referent: 'test_results',
+            },
+            {
+              name: 'patient_gender_legal',
+              credentialDefinitionId: credDefID,
+              referent: 'test_results',
+            },
+            {
+              name: 'patient_country',
+              credentialDefinitionId: credDefID,
+              referent: 'test_results',
+            },
+            {
+              name: 'patient_email',
+              credentialDefinitionId: credDefID,
+              referent: 'test_results',
+            },
+            {
+              name: 'exemption_expiration_date',
+              credentialDefinitionId: credDefID,
+              referent: 'test_results',
+            },
+          ],
+          predicates: [],
+        }
+    
+        setWorkflow('sending-vaccination-exemption')
+
+        break
+      default:
+        console.warn(`Unknown Credential to propose presentation for by Credential Definition ID ${credDefID}`)
+        return
+    }
+
+    console.log('Proposing presentation', presentationPreview)
+    await agentContext.agent.proofs.proposeProof(
+      governmentConnectionId,
+      presentationPreview,
+    )
+  }
+
 
   const handleBasicMessage = async (event) => {
     console.log('Received Basic Message Event', event)
@@ -726,7 +913,7 @@ function Workflow(props) {
         }}
       />
 
-<Route
+      <Route
         path={`${url}/accepted-test-result`}
         render={() => {
           return (
@@ -740,67 +927,9 @@ function Workflow(props) {
                 text: 'Share now',
                 textColor: 'white',
                 backgroundColor: AppStyles.secondaryBackground.backgroundColor,
-                action: async () => {
-                  const governmentConnectionId = await getData(
-                    'governmentConnectionId',
-                  )
-
-                  if (!governmentConnectionId) {
-                    //TODO: Change to throw an error
-                    console.warn('Unable to get government connection Id')
-                  }
-
-                  console.log('Proposing presentation to government agent')
-
-                  const credDefId = Config.LAB_RESULT_CRED_DEF_ID
-
-                  console.log(
-                    'Cred Def ID for presentation proposal:',
-                    credDefId,
-                  )
-
-                  const presentationPreview = {
-                    '@type':
-                      'https://didcomm.org/present-proof/1.0/presentation-preview',
-                    attributes: [
-                      {
-                        name: 'patient_surnames',
-                        credentialDefinitionId: credDefId,
-                        referent: 'test_results',
-                      },
-                      {
-                        name: 'patient_given_names',
-                        credentialDefinitionId: credDefId,
-                        referent: 'test_results',
-                      },
-                      {
-                        name: 'patient_date_of_birth',
-                        credentialDefinitionId: credDefId,
-                        referent: 'test_results',
-                      },
-                      {
-                        name: 'lab_specimen_collected_date',
-                        credentialDefinitionId: credDefId,
-                        referent: 'test_results',
-                      },
-                      {
-                        name: 'lab_observation_date_time',
-                        credentialDefinitionId: credDefId,
-                        referent: 'test_results',
-                      },
-                    ],
-                    predicates: [],
-                  }
-
-                  setWorkflow('sending-test-result')
-
-                  console.log('Proposing presentation', presentationPreview)
-                  await agentContext.agent.proofs.proposeProof(
-                    governmentConnectionId,
-                    presentationPreview,
-                  )
-                },
-              }}></Message>
+                action: () => shareCredentialForTrustedTraveler(Config.LAB_RESULT_CRED_DEF_ID),
+              }}
+            />
           )
         }}
       />
@@ -817,7 +946,7 @@ function Workflow(props) {
         }}
       />
 
-<Route
+      <Route
         path={`${url}/accepted-vaccination`}
         render={() => {
           return (
@@ -831,72 +960,9 @@ function Workflow(props) {
                 text: 'Share now',
                 textColor: 'white',
                 backgroundColor: AppStyles.secondaryBackground.backgroundColor,
-                action: async () => {
-                  const governmentConnectionId = await getData(
-                    'governmentConnectionId',
-                  )
-
-                  if (!governmentConnectionId) {
-                    //TODO: Change to throw an error
-                    console.warn('Unable to get government connection Id')
-                  }
-
-                  console.log('Proposing Vaccine presentation to government agent')
-
-                  const credDefId = Config.VACCINATION_CRED_DEF_ID
-
-                  console.log(
-                    'Cred Def ID for presentation proposal:',
-                    credDefId,
-                  )
-
-                  const presentationPreview = {
-                    '@type':
-                      'https://didcomm.org/present-proof/1.0/presentation-preview',
-                    attributes: [
-                      {
-                        name: 'patient_surnames',
-                        credentialDefinitionId: credDefId,
-                        referent: 'test_results',
-                      },
-                      {
-                        name: 'patient_given_names',
-                        credentialDefinitionId: credDefId,
-                        referent: 'test_results',
-                      },
-                      {
-                        name: 'patient_date_of_birth',
-                        credentialDefinitionId: credDefId,
-                        referent: 'test_results',
-                      },
-                      {
-                        name: 'vaccine_disease_target_name',
-                        credentialDefinitionId: credDefId,
-                        referent: 'test_results',
-                      },
-                      {
-                        name: 'vaccine_administration_date',
-                        credentialDefinitionId: credDefId,
-                        referent: 'test_results',
-                      },
-                      {
-                        name: 'series_complete',
-                        credentialDefinitionId: credDefId,
-                        referent: 'test_results',
-                      },
-                    ],
-                    predicates: [],
-                  }
-
-                  setWorkflow('sending-vaccination')
-
-                  console.log('Proposing presentation', presentationPreview)
-                  await agentContext.agent.proofs.proposeProof(
-                    governmentConnectionId,
-                    presentationPreview,
-                  )
-                },
-              }}></Message>
+                action: () => shareCredentialForTrustedTraveler(Config.VACCINATION_CRED_DEF_ID),
+              }}
+            />
           )
         }}
       />
@@ -927,67 +993,9 @@ function Workflow(props) {
                 text: 'Share now',
                 textColor: 'white',
                 backgroundColor: AppStyles.secondaryBackground.backgroundColor,
-                action: async () => {
-                  const governmentConnectionId = await getData(
-                    'governmentConnectionId',
-                  )
-
-                  if (!governmentConnectionId) {
-                    //TODO: Change to throw an error
-                    console.warn('Unable to get government connection Id')
-                  }
-
-                  console.log('Proposing Vaccine Exemption presentation to government agent')
-
-                  const credDefId = Config.EXEMPTION_CRED_DEF_ID
-
-                  console.log(
-                    'Cred Def ID for presentation proposal:',
-                    credDefId,
-                  )
-
-                  const presentationPreview = {
-                    '@type':
-                      'https://didcomm.org/present-proof/1.0/presentation-preview',
-                    attributes: [
-                      {
-                        name: 'patient_surnames',
-                        credentialDefinitionId: credDefId,
-                        referent: 'test_results',
-                      },
-                      {
-                        name: 'patient_given_names',
-                        credentialDefinitionId: credDefId,
-                        referent: 'test_results',
-                      },
-                      {
-                        name: 'patient_date_of_birth',
-                        credentialDefinitionId: credDefId,
-                        referent: 'test_results',
-                      },
-                      {
-                        name: 'exemption_issue_date',
-                        credentialDefinitionId: credDefId,
-                        referent: 'test_results',
-                      },
-                      {
-                        name: 'exemption_expiration_date',
-                        credentialDefinitionId: credDefId,
-                        referent: 'test_results',
-                      },
-                    ],
-                    predicates: [],
-                  }
-
-                  setWorkflow('sending-vaccination-exemption')
-
-                  console.log('Proposing presentation', presentationPreview)
-                  await agentContext.agent.proofs.proposeProof(
-                    governmentConnectionId,
-                    presentationPreview,
-                  )
-                },
-              }}></Message>
+                action: () => shareCredentialForTrustedTraveler(Config.EXEMPTION_CRED_DEF_ID),
+              }}
+            />
           )
         }}
       />

--- a/configs/credentialConfigs.js
+++ b/configs/credentialConfigs.js
@@ -1,9 +1,9 @@
 export const Schemas = {
-  LabOrder: 'QiPGTNiyXnS218AoTK8h39:2:Lab_Order:1.2',
-  LabResult: 'QiPGTNiyXnS218AoTK8h39:2:Lab_Result:1.1',
-  TrustedTraveler: 'X2JpGAqC7ZFY4hwKG6kLw9:2:Trusted_Traveler:1.0',
-  Vaccination: 'QiPGTNiyXnS218AoTK8h39:2:Vaccination:1.2',
-  VaccinationExemption: 'QiPGTNiyXnS218AoTK8h39:2:Vaccine_Exemption:1.1',
+  LabOrder: 'RuuJwd3JMffNwZ43DcJKN1:2:Lab_Order:1.4',
+  LabResult: 'RuuJwd3JMffNwZ43DcJKN1:2:Lab_Result:1.4',
+  TrustedTraveler: 'RuuJwd3JMffNwZ43DcJKN1:2:Trusted_Traveler:1.4',
+  Vaccination: 'RuuJwd3JMffNwZ43DcJKN1:2:Vaccination:1.4',
+  VaccinationExemption: 'RuuJwd3JMffNwZ43DcJKN1:2:Vaccine_Exemption:1.4',
 }
 
 const credentialConfigs = {

--- a/configs/credentialConfigs.js
+++ b/configs/credentialConfigs.js
@@ -1,18 +1,27 @@
+export const Schemas = {
+  LabOrder: 'QiPGTNiyXnS218AoTK8h39:2:Lab_Order:1.2',
+  LabResult: 'QiPGTNiyXnS218AoTK8h39:2:Lab_Result:1.1',
+  TrustedTraveler: 'X2JpGAqC7ZFY4hwKG6kLw9:2:Trusted_Traveler:1.0',
+  Vaccination: 'QiPGTNiyXnS218AoTK8h39:2:Vaccination:1.2',
+  VaccinationExemption: 'QiPGTNiyXnS218AoTK8h39:2:Vaccine_Exemption:1.1',
+}
+
 const credentialConfigs = {
-  'X2JpGAqC7ZFY4hwKG6kLw9:2:Test_ID:1.2': {
+  [Schemas.LabOrder]: {
     credentialName: 'Health Test Record',
   },
-  'X2JpGAqC7ZFY4hwKG6kLw9:2:Covid_19_Lab_Result:1.5': {
+  [Schemas.LabResult]: {
     credentialName: 'Health Test Result',
   },
-  'X2JpGAqC7ZFY4hwKG6kLw9:2:Trusted_Traveler:1.0': {
+  [Schemas.TrustedTraveler]: {
     credentialName: 'Happy Traveler Card',
+  },
+  [Schemas.Vaccination]: {
+    credentialName: 'Health Vaccination Record',
+  },
+  [Schemas.VaccinationExemption]: {
+    credentialName: 'Health Vaccination Exemption Record',
   },
 }
 
 export default credentialConfigs
-
-export const Schemas = {
-  LabResult: 'X2JpGAqC7ZFY4hwKG6kLw9:2:Covid_19_Lab_Result:1.5',
-  TrustedTraveler: 'X2JpGAqC7ZFY4hwKG6kLw9:2:Trusted_Traveler:1.0',
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cardeaholder",
-  "version": "2.0.2",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
# Summary of Changes

This PR is based off of #9. Additional contributors: @seajensen, @reflectivedevelopment, @ryanindicio. This alters the behavior to send self attested demographic data in a presentation request. This PR also allows the presentation of vaccination and vaccination exemptions to receive a trusted traveler. Performed some refactoring on the presentation process.

# Related Issues

#9

# Pull Request Checklist

This is just a reminder about the most common mistakes. Please make sure that you tick all _appropriate_ boxes. But please read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this).
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components.
- [x] Added **tests** for changed code (run `scripts/preflight` to run tests and check code style).
- [x] Prefixed code comments with GitHub nick and an appropriate prefix.
- [x] Coding style is consistent with the rest of the framework.
- [x] Updated **documentation** for changed code and new or modified features.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

_PR template adapted from the Python attrs project._
